### PR TITLE
 末尾再帰最適化の実装

### DIFF
--- a/Factorial.scala
+++ b/Factorial.scala
@@ -1,7 +1,6 @@
 import scala.math.BigInt
 
-object Factorial extends App {
-  def factorial(i: BigInt): BigInt = if (i == 0) 1 else i * factorial(i - 1)
-
-  println(factorial(10000))
+object FactorialTailRec extends App {
+  def factorial(i: BigInt, acc: BigInt): BigInt = if (i == 0) acc else factorial(i - 1, i * acc) 
+  println(factorial(10000, 1))
 }

--- a/Factorial.scala
+++ b/Factorial.scala
@@ -1,6 +1,6 @@
 import scala.math.BigInt
 
 object FactorialTailRec extends App {
-  def factorial(i: BigInt, acc: BigInt): BigInt = if (i == 0) acc else factorial(i - 1, i * acc) 
+  def factorial(i: Int, acc: BigInt): BigInt = if (i == 0) acc else factorial(i - 1, i * acc) 
   println(factorial(10000, 1))
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.4


### PR DESCRIPTION
`i * factorial(i - 1)`でreturnしていたのを`factorial(i - 1, i * acc)`に変更することでスタックの消費が抑えられる、というのがなんとなく分かった。