### PR TITLE
fix(unit): 階乗を定義した関数に末尾最適化を施した

### DIFF
--- a/Factorial.scala
+++ b/Factorial.scala
@@ -1,10 +1,13 @@
 import scala.math.BigInt
 
 object Factorial extends App {
+  // テスト対象とする値を定数化
+  val test_value_for_factorial :Int = 30000
+
   @scala.annotation.tailrec
   def factorial(i: BigInt, acc: BigInt = 1): BigInt =
     if (i == 0) acc
     else factorial(i - 1, i * acc)
 
-  println(factorial(3000))
+  println(factorial(test_value_for_factorial))
 }

--- a/Factorial.scala
+++ b/Factorial.scala
@@ -1,7 +1,10 @@
 import scala.math.BigInt
 
 object Factorial extends App {
-  def factorial(i: BigInt): BigInt = if (i == 0) 1 else i * factorial(i - 1)
+  @scala.annotation.tailrec
+  def factorial(i: BigInt, acc: BigInt = 1): BigInt =
+    if (i == 0) acc
+    else factorial(i - 1, i * acc)
 
-  println(factorial(10000))
+  println(factorial(3000))
 }


### PR DESCRIPTION
## Context
- 受講中の講座のコーディング課題である
  - 有料の内容を含むので、リンクはあえて貼らないでおく

## Problem
- 既存コードでは下記の問題が生じる
  - 今回の試行値``30000``で``factorial()``関数を実行しようとするとスタックオーバーフローで落ちる
    - これは、コンパイル時の最適化で回避できる問題である

## Solution
- 末尾最適化によるコンパイル時最適化が適用されるよう、実装し直した。ポイントは下記二点に要約できるだろう
  - 元の関数の第二引数にアキュムレータを追加
  - 再帰の評価が関数の末尾に来るように実装し直した

## Testing
- 手動でコンパイル→実行した
  - @tailrecアノテーションにより末尾最適化自体を検査しているため、コンパイルエラーが出ていなければ問題ないだろうと思うものの
  - **階乗処理自体のUnitTestは書かれていない**

実行結果の頭の方をとりあえず載せておく
```
27595372462193845993799421664254627839807620445293309855296350368000（後略）
```