### PR TITLE
階上の計算でスタックオーバフローが発生する不具合を修正

### DIFF
--- a/Factorial.scala
+++ b/Factorial.scala
@@ -1,7 +1,7 @@
 import scala.math.BigInt
 
 object Factorial extends App {
-  def factorial(i: BigInt): BigInt = if (i == 0) 1 else i * factorial(i - 1)
+  def factorial(i: BigInt, j: BigInt): BigInt = if (i == 0) j else factorial(i - 1, i * j)
 
-  println(factorial(10000))
+  println(factorial(9999, 10000))
 }


### PR DESCRIPTION
階上の処理が再帰を用いているため、引数に大きな数値を入れると再帰呼び出しによってスタックオーバーフローが発生する。
これを防ぐために末尾再帰最適化が行われるように変更した。